### PR TITLE
use fs.exists in favor of deprecated path.exits

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -51,13 +51,13 @@ http.createServer(function (req, res) {
     if (uri === '/') {
         uri = command.default;
     }
-    
+
     // Path relative to process
     var filename    = path.join(process.cwd(), uri);
 
     // Check for file existence
-    path.exists(filename, function(exists) {
-        
+    fs.exists(filename, function(exists) {
+
         // 404
         if (!exists) {
             res.writeHead(404, {'Content-Type': 'text/plain'});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "",
   "name": "simple",
   "description": "A naive Node.js clone of Python's simpleHttpServer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "url": "https://github.com/thisandagain/simple.git"
   },


### PR DESCRIPTION
Hello, found that path.exists no longer exists after upgrading node.   It looks like this functionality moved to fs a long time ago.   Before node 0.10.40 in any event.   Any objection to moving forward?

Best Regards,
Peter
